### PR TITLE
Memory saving for Q

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -36,11 +36,16 @@
          "affiliation": "Université de Montréal",
          "name": "Banville, Francis",
          "orcid": "0000-0001-9051-0597"
-      }, 
+      },
       {
       "affiliation": "School of Mathematics and Statistics, University of Canterbury",
       "name": "Dalla Riva, Giulio V.",
       "orcid": "0000-0002-3454-0633"
+      },
+      {
+      "affiliation": "Tokyo University of Technology",
+      "name": "Shuta Ito",
+      "orcid": "0000-0003-0030-4648"
       }
    ],
    "access_right": "open",

--- a/src/modularity/utilities.jl
+++ b/src/modularity/utilities.jl
@@ -33,23 +33,25 @@ function Q(N::T, L::Dict{E,Int64}) where {T<:AbstractEcologicalNetwork,E}
 
     # Degrees
     dkin, dkout = degree_in(N), degree_out(N)
-    kin = map(x -> dkin[x], species(N; dims=2))
-    kout = map(x -> dkout[x], species(N; dims=1))
+    names1 = species(N; dims=2)
+    names2 = species(N; dims=1)
+    kin = map(x -> dkin[x], names1)
+    kout = map(x -> dkout[x], names2)
 
     # Value of m -- sum of weights, total number of int, ...
     m = links(N)
+    modularity = 0.0
+    for c in 1:length(kin)
+      for r in 1:length(kout)
+        name1 = names1[c]
+        name2 = names2[r]
+        if L[name1] != L[name2] continue end
+        modularity += (N.edges[r, c]) - (kout[r] * kin[c] / m)
+      end
+    end
+    modularity /= m
 
-    # Null model
-    kikj = (kout .* kin')
-    Pij = kikj ./ m
-
-    # Difference
-    diff = N.edges .- Pij
-
-    # Diff × delta
-    dd = diff .* δ(N,L)
-
-    return sum(dd)/m
+    return modularity
 end
 
 """

--- a/src/modularity/utilities.jl
+++ b/src/modularity/utilities.jl
@@ -41,12 +41,12 @@ function Q(N::T, L::Dict{E,Int64}) where {T<:AbstractEcologicalNetwork,E}
     # Value of m -- sum of weights, total number of int, ...
     m = links(N)
     modularity = 0.0
-    for c in 1:length(kin)
-      for r in 1:length(kout)
-        name1 = names1[c]
-        name2 = names2[r]
+    for i in 1:length(kin)
+      for j in 1:length(kout)
+        name1 = names1[i]
+        name2 = names2[j]
         if L[name1] != L[name2] continue end
-        modularity += (N.edges[r, c]) - (kout[r] * kin[c] / m)
+        modularity += (N.edges[j, i]) - (kout[j] * kin[i] / m)
       end
     end
     modularity /= m


### PR DESCRIPTION
# Memory saving for Q


<!-- Thank you for this pull request! Please replace any information between curly brackets {like so} with the relevant information. -->

When computing modularity using the function Q, many elements of kikj, P, and diff are useless. (Because at the end of the computation, the function takes a product with $\delta(N, L)$, a sparse matrix.) 
So change the code so that the function Q works without wasted elements.

I tried to benchmark before and after the change.
Before
```jl
julia> N = convert(BipartiteNetwork, web_of_life("M_PL_015"))
666×131 (String) bipartite ecological network (L: 2933 - Bool)

julia> tmp = n_random_modules(100)(N)
(666×131 (String) bipartite ecological network (L: 2933 - Bool), Dict("Bombylius undatus
 " => 64,"Sarcopoterium spinosum" => 29,"Lasioglossum crassepunctatum" => 6,"Euodynerus
velutinus" => 16,"Leptochilus alpestris" => 71,"Nomada mavromoustakisi" => 55,"Psallus s
p1 M_PL_015" => 52,"Osmia subcornuta" => 29,"Amphicoma distincta" => 29,"Psilothrix cyan
eus " => 23…))

julia> @benchmark Q(tmp...)
BenchmarkTools.Trial:
  memory estimate:  9.86 MiB
  allocs estimate:  903
  --------------
  minimum time:     5.520 ms (0.00% GC)
  median time:      6.262 ms (0.00% GC)
  mean time:        6.672 ms (5.08% GC)
  maximum time:     11.120 ms (15.41% GC)
  --------------
  samples:          749
  evals/sample:     1


```
After
```jl

julia> @benchmark Q(tmp...)
BenchmarkTools.Trial:
  memory estimate:  180.19 KiB
  allocs estimate:  3636
  --------------
  minimum time:     4.190 ms (0.00% GC)
  median time:      5.002 ms (0.00% GC)
  mean time:        5.251 ms (0.16% GC)
  maximum time:     9.538 ms (32.33% GC)
  --------------
  samples:          952
  evals/sample:     1
```
Presumably, when the number of vertices is N, the space computation has been improved from O(N^2) to O(N).
(Perhaps the amount of time computation can be improved by a constant factor.)

## Related issues

<!-- If relevant, please add links to the relevant issues, using `#00` -->

## Checklist

- [x] The code is covered by unit tests (I did not make any changes to the tests, because I did not change the function behavior.)
  - [ ] Additional cases or module in `test/...`
  - [ ] Relevant lines in `test/runtests.jl`
 - [ ] The code is *documented* (Likewise, there are no changes to the documentation.)
  - [ ] Docstrings written for every function
  - [ ] If needed, additional lines in `docs/src/...`
- [x] All contributors have added their name and affiliation to `.zenodo.json`

## Pinging

Pinging @tpoisot
