### PR TITLE
Improved performance of function lp

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "EcologicalNetworks"
 uuid = "f03a62fe-f8ab-5b77-a061-bb599b765229"
 authors = ["Timothée Poisot <timothee.poisot@umontreal.ca>"]
 repo = "https://github.com/EcoJulia/EcologicalNetworks.jl"
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/modularity/labelpropagation.jl
+++ b/src/modularity/labelpropagation.jl
@@ -13,7 +13,7 @@ Networks, in: 2009 IEEE/WIC/ACM International Joint Conference on Web
 Intelligence and Intelligent Agent Technology. Institute of Electrical &
 Electronics Engineers (IEEE). https://doi.org/10.1109/wi-iat.2009.15
 """
-function lp(N::T) where {T<:AbstractBipartiteNetwork}
+function lp(N::T) where {T<:AbstractEcologicalNetwork}
   L = Dict([species(N)[i]=>i for i in 1:richness(N)])
 
   rows, cols, vals = findnz(N.edges)
@@ -39,10 +39,10 @@ function lp(N::T) where {T<:AbstractBipartiteNetwork}
       linked = neighbors_t[s1]
       labels = [L[s2] for s2 in linked]
       if length(labels) > 0
-        counts = StatsBase.counts(labels)
-        cmax = maximum(counts)
-        merged = Dict(zip(labels, counts))
-        ok_keys = keys(Dict(collect(filter(k -> k.second==cmax, merged))))
+        counts = Dict()
+        (i->counts[i] = get(counts, i, 0) + 1).(labels)
+        cmax = maximum(values(counts))
+        ok_keys = keys(filter(k -> k.second==cmax, counts))
         if length(ok_keys) > 0
           newlab = StatsBase.sample(collect(ok_keys))
           L[s1] = newlab
@@ -54,10 +54,10 @@ function lp(N::T) where {T<:AbstractBipartiteNetwork}
       linked = neighbors_b[s2]
       labels = [L[s1] for s1 in linked]
       if length(labels) > 0
-        counts = StatsBase.counts(labels)
-        cmax = maximum(counts)
-        merged = Dict(zip(labels, counts))
-        ok_keys = keys(Dict(collect(filter(k -> k.second==cmax, merged))))
+        counts = Dict()
+        (i->counts[i] = get(counts, i, 0) + 1).(labels)
+        cmax = maximum(values(counts))
+        ok_keys = keys(filter(k -> k.second==cmax, counts))
         if length(ok_keys) > 0
           newlab = StatsBase.sample(collect(ok_keys))
           L[s2] = newlab

--- a/src/modularity/labelpropagation.jl
+++ b/src/modularity/labelpropagation.jl
@@ -13,21 +13,6 @@ Networks, in: 2009 IEEE/WIC/ACM International Joint Conference on Web
 Intelligence and Intelligent Agent Technology. Institute of Electrical &
 Electronics Engineers (IEEE). https://doi.org/10.1109/wi-iat.2009.15
 """
-"""
-    lp(N::T) where {T<:AbstractEcologicalNetwork}
-
-Uses label propagation to generate a first approximation of the modular
-structure of a network. This is usually followed by the BRIM (`brim`) method.
-This method supposedly performs better for large graphs, but we rarely observed
-any differences between it and variations of BRIM alone on smaller graphs.
-
-#### References
-
-Liu, X., Murata, T., 2009. Community Detection in Large-Scale Bipartite
-Networks, in: 2009 IEEE/WIC/ACM International Joint Conference on Web
-Intelligence and Intelligent Agent Technology. Institute of Electrical &
-Electronics Engineers (IEEE). https://doi.org/10.1109/wi-iat.2009.15
-"""
 function lp(N::T) where {T<:AbstractEcologicalNetwork}
   L = Dict([species(N)[i]=>i for i in 1:richness(N)])
   

--- a/src/modularity/labelpropagation.jl
+++ b/src/modularity/labelpropagation.jl
@@ -13,18 +13,26 @@ Networks, in: 2009 IEEE/WIC/ACM International Joint Conference on Web
 Intelligence and Intelligent Agent Technology. Institute of Electrical &
 Electronics Engineers (IEEE). https://doi.org/10.1109/wi-iat.2009.15
 """
+"""
+    lp(N::T) where {T<:AbstractEcologicalNetwork}
+
+Uses label propagation to generate a first approximation of the modular
+structure of a network. This is usually followed by the BRIM (`brim`) method.
+This method supposedly performs better for large graphs, but we rarely observed
+any differences between it and variations of BRIM alone on smaller graphs.
+
+#### References
+
+Liu, X., Murata, T., 2009. Community Detection in Large-Scale Bipartite
+Networks, in: 2009 IEEE/WIC/ACM International Joint Conference on Web
+Intelligence and Intelligent Agent Technology. Institute of Electrical &
+Electronics Engineers (IEEE). https://doi.org/10.1109/wi-iat.2009.15
+"""
 function lp(N::T) where {T<:AbstractEcologicalNetwork}
   L = Dict([species(N)[i]=>i for i in 1:richness(N)])
-
-  rows, cols, vals = findnz(N.edges)
-  neighbors_t = Dict([i=>[] for i in species(N, dims=1)])
-  neighbors_b = Dict([i=>[] for i in species(N, dims=2)])
-  for (i, j) in zip(rows, cols)
-    name_t = species(N, dims=1)[i]
-    name_b = species(N, dims=2)[j]
-    push!(neighbors_t[name_t], name_b)
-    push!(neighbors_b[name_b], name_t)
-  end
+  
+  neighbors_b = Dict([s=>N[:,s] for s in species(N, dims=2)])
+  neighbors_t = Dict([s=>N[s,:] for s in species(N, dims=1)])
 
   # Initial modularity
   imod = Q(N, L)


### PR DESCRIPTION
# Improved performance of function lp

<!-- Thank you for this pull request! Please replace any information between curly brackets {like so} with the relevant information. -->
Improved the performance of function lp.
In this function, the following two factors had a significant impact on the performance.

The first is to retrieve the adjacent vertex each time for each vertex.
```jl
linked = filter(s2 -> has_interaction(N,s1,s2), species(N; dims=2))
```
When the number of vertices is N, the computational complexity of this operation is O(N). In the original code, this operation is performed on all vertices, so the computational complexity is O(N^2), which is very slow.
In this fix, adjacent vertices are now precomputed and retained.

The other is the format of the counts variable.
```jl
counts = StatsBase.counts(labels)
```
Before the fix, the function Stats.counts was used to counting the occurrences of labels.
However, if the neighboring labels are far apart in value, there will be many zeroes in the array. (For example, applying the Stats.counts function to [1, 100] would result in [1, 0, ... , 0, 1], resulting in 98 useless elements.)
This information is not only useless but also computationally expensive when knowing the most occurring labels.
In this fix, the information of non-adjacent labels is not retained.

(Also, in the Stats.counts function, if the label value does not start from 1, the return array will start from the smallest label value. (For example. If the label is [2], the Stats.count function will return [1] instead of [0, 1].) This was causing a bug, which has also been fixed.)

I tried to benchmark before and after the change.

Before
```jl
julia> N = convert(BipartiteNetwork, web_of_life("M_PL_015"))
666×131 (String) bipartite ecological network (L: 2933 - Bool)

julia> @benchmark lp(N)
BenchmarkTools.Trial: 
  memory estimate:  13.05 MiB
  allocs estimate:  55064
  --------------
  minimum time:     940.893 ms (0.00% GC)
  median time:      2.017 s (0.00% GC)
  mean time:        2.298 s (0.11% GC)
  maximum time:     3.937 s (0.19% GC)
  --------------
  samples:          3
  evals/sample:     1
```

After
```jl
julia> @benchmark lp(N)
BenchmarkTools.Trial: 
  memory estimate:  12.42 MiB
  allocs estimate:  165736
  --------------
  minimum time:     27.190 ms (0.00% GC)
  median time:      39.667 ms (0.00% GC)
  mean time:        43.406 ms (2.12% GC)
  maximum time:     98.638 ms (0.00% GC)
  --------------
  samples:          116
  evals/sample:     1
```


## Related issues

<!-- If relevant, please add links to the relevant issues, using `#00` -->

## Checklist

- [x] The code is covered by unit tests
  - [ ] Additional cases or module in `test/...`
  - [ ] Relevant lines in `test/runtests.jl`
- [ ] The code is *documented*
  - [ ] Docstrings written for every function
  - [ ] If needed, additional lines in `docs/src/...`
- [x] All contributors have added their name and affiliation to `.zenodo.json`

I did not make any changes to the tests and document, because I did not change the function behavior.

## Pinging

Pinging @tpoisot
