### PR TITLE
Trophic bugfixes

### DIFF
--- a/src/foodwebs/omnivory.jl
+++ b/src/foodwebs/omnivory.jl
@@ -1,8 +1,8 @@
 function omnivory(N::T) where {T <: UnipartiteNetwork}
     OI = Dict([s => 0.0 for s in species(N)])
 
-    TL = fractional_trophic_level(N)
-    k = degree(N; dims=1)
+    TL = trophic_level(N)
+    k = degree_in(N)
 
     for sp_i in species(N)
 
@@ -11,10 +11,10 @@ function omnivory(N::T) where {T <: UnipartiteNetwork}
 
         # For every species, we set its initial omnivory to 0
         oi = 0.0
-        for (j, sp_j) in enumerate(species(N))
+        for sp_j in species(N)
             # Then for every species it consumes, we ha
             tl_diff = (TL[sp_j] - (TL[sp_i]-1.0)).^2.0
-            corr = N[sp_i,sp_j]/k[sp_i]
+            corr = N[sp_j,sp_i]/k[sp_i]
             oi += tl_diff * corr
         end
         OI[sp_i] = oi

--- a/src/foodwebs/omnivory.jl
+++ b/src/foodwebs/omnivory.jl
@@ -1,3 +1,16 @@
+"""
+    omnivory(N::T) where {T <: UnipartiteNetwork}
+
+Returns a vector of length |species(N)| with an index of consumption across
+trophic levels. Note we explicitly assume that diet contribution is spread
+evenly across prey species.
+
+#### References
+- Christensen, Villy, and Daniel Pauly. "ECOPATH II—a software for balancing
+  steady-state ecosystem models and calculating network characteristics."
+  Ecological modelling 61, no. 3-4 (1992): 169-185.
+
+"""
 function omnivory(N::T) where {T <: UnipartiteNetwork}
     OI = Dict([s => 0.0 for s in species(N)])
 


### PR DESCRIPTION
# Several bugs fixes in calculating trophic levels and omnivory

This pull request will hopefully address some inconsistencies and bugs in trophiclevels.jl and omnivory.jl.

Specifically:

- [ ] The functions for calculating trophic level and omnivory use an unconventional convention for trophic link direction. This means that in several places out-degree is used rather than in-degree, and in others there is inconsistent use of degree
- [ ] Related, in some places iteration is over predators rather than prey
- [ ] The calculation of shortest paths associated with trophic level calculation uses the maximal shortest path rather than the minimal as expected
- [x] the calculation of omnivory uses shortest paths rather than true trophic level

## Related issues
#202

## Checklist

- [ ] The code is covered by unit tests
  - [ ] Additional cases or module in `test/...`
  - [ ] Relevant lines in `test/runtests.jl`
- [ ] The code is *documented*
  - [ ] Docstrings written for every function
  - [ ] If needed, additional lines in `docs/src/...`
- [ ] All contributors have added their name and affiliation to `.zenodo.json`

## Pinging

Pinging @tpoisot
